### PR TITLE
Promote MoonBit checks for 20260517

### DIFF
--- a/report.md
+++ b/report.md
@@ -1,0 +1,19 @@
+# Test Report
+
+## Command
+
+`moon test`
+
+## Relevant output
+
+```text
+/usr/bin/ld: cannot find -ltchproxy: No such file or directory
+collect2: error: ld returned 1 exit status
+```
+
+## Analysis
+
+The fallback test command reaches native linking but the local environment does
+not provide `libtchproxy`. The repository's `torch/moon.pkg` links native tests
+with `-ltchproxy`, so the failure is an unavailable external native dependency,
+not a MoonBit source failure from this promotion.

--- a/torch/moon.pkg
+++ b/torch/moon.pkg
@@ -1,3 +1,7 @@
+import {
+  "moonbitlang/core/debug",
+}
+
 warnings = "-5"
 
 options(

--- a/torch/tensor.mbt
+++ b/torch/tensor.mbt
@@ -454,7 +454,7 @@ test "tensor_length" {
 test "tensor_shape" {
   let tensor_a = tensor_from_array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
   let shape = tensor_a.shape()
-  inspect(shape, content="[6]")
+  @debug.debug_inspect(shape, content="[6]")
 }
 
 ///|


### PR DESCRIPTION
## Summary
- Update code/tests for current MoonBit diagnostics.
- Add `report.md` for the missing native `libtchproxy` test dependency.

## Notes
- Branch: `promote-20260517`